### PR TITLE
Add provider audit pipeline support

### DIFF
--- a/app/backend/app/db/audit.py
+++ b/app/backend/app/db/audit.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any, AsyncIterator, Optional, TYPE_CHECKING
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from . import models
+from .session import SessionLocal
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..services.provider import CallStats
+
+
+@asynccontextmanager
+async def _scoped_session(session: Optional[AsyncSession]) -> AsyncIterator[AsyncSession]:
+    if session is not None and session.bind is not None:
+        maker = async_sessionmaker(bind=session.bind, expire_on_commit=False)
+        async with maker() as scoped:
+            yield scoped
+    else:
+        async with SessionLocal() as scoped:
+            yield scoped
+
+
+def _set_if_exists(obj: Any, attr: str, value: Any) -> None:
+    if value is None:
+        return
+    if hasattr(obj, attr):
+        setattr(obj, attr, value)
+
+
+def _collect_token_updates(model_cls: type, stats: "CallStats") -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    if hasattr(model_cls, "prompt_tokens"):
+        values["prompt_tokens"] = stats.prompt_tokens
+    if hasattr(model_cls, "completion_tokens"):
+        values["completion_tokens"] = stats.completion_tokens
+    if hasattr(model_cls, "total_tokens"):
+        values["total_tokens"] = stats.total_tokens
+    if hasattr(model_cls, "cost_cents") and stats.cost_cents is not None:
+        values["cost_cents"] = stats.cost_cents
+    return values
+
+
+async def audit_runs_insert_start(
+    *,
+    session: Optional[AsyncSession],
+    run_id: str,
+    relation_id: str,
+    stage: str,
+    model_ctx: dict[str, Any],
+    started_at: datetime,
+) -> None:
+    model_cls = getattr(models, "AuditRun2", models.AuditRun)
+    async with _scoped_session(session) as scoped:
+        try:
+            record = model_cls(run_id=run_id)
+            _set_if_exists(record, "relation_id", relation_id)
+            _set_if_exists(record, "rel_id", relation_id)
+            _set_if_exists(record, "stage", stage)
+            _set_if_exists(record, "kind", stage)
+            _set_if_exists(record, "model", model_ctx.get("model"))
+            _set_if_exists(record, "provider", model_ctx.get("provider"))
+            _set_if_exists(record, "metadata", model_ctx)
+            _set_if_exists(record, "model_ctx", model_ctx)
+            _set_if_exists(record, "started_at", started_at)
+            _set_if_exists(record, "status", "running")
+            await scoped.merge(record)
+            await scoped.commit()
+        except Exception:
+            await scoped.rollback()
+
+
+async def audit_runs_insert_tokens(
+    *,
+    session: Optional[AsyncSession],
+    run_id: str,
+    stats: "CallStats",
+) -> None:
+    model_cls = getattr(models, "AuditRun2", models.AuditRun)
+    values = _collect_token_updates(model_cls, stats)
+    if not values:
+        return
+    async with _scoped_session(session) as scoped:
+        try:
+            stmt = (
+                update(model_cls)
+                .where(model_cls.run_id == run_id)
+                .values(**values)
+            )
+            await scoped.execute(stmt)
+            await scoped.commit()
+        except Exception:
+            await scoped.rollback()
+
+
+async def audit_runs_insert_finish(
+    *,
+    session: Optional[AsyncSession],
+    run_id: str,
+    finished_at: datetime,
+    status: str,
+    cost_cents: Optional[int] = None,
+) -> None:
+    model_cls = getattr(models, "AuditRun2", models.AuditRun)
+    values: dict[str, Any] = {}
+    if hasattr(model_cls, "finished_at"):
+        values["finished_at"] = finished_at
+    if hasattr(model_cls, "status"):
+        values["status"] = status
+    if hasattr(model_cls, "cost_cents") and cost_cents is not None:
+        values.setdefault("cost_cents", cost_cents)
+    if not values:
+        return
+    async with _scoped_session(session) as scoped:
+        try:
+            stmt = (
+                update(model_cls)
+                .where(model_cls.run_id == run_id)
+                .values(**values)
+            )
+            await scoped.execute(stmt)
+            await scoped.commit()
+        except Exception:
+            await scoped.rollback()

--- a/app/backend/app/services/provider.py
+++ b/app/backend/app/services/provider.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from openai import AsyncOpenAI
+
+from ..config import get_settings
+
+
+@dataclass
+class CallStats:
+    """Aggregated statistics for a single LLM call."""
+
+    model: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_cents: int = 0
+
+
+# Pricing map expressed in cents per 1M tokens.
+_MODEL_PRICING: Dict[str, Tuple[int, int]] = {
+    "gpt-4o-mini": (15, 60),
+    "gpt-4o": (500, 1500),
+    "gpt-3.5-turbo": (150, 400),
+    "glm-4": (100, 100),
+    "glm-4-air": (20, 80),
+}
+
+
+def _resolve_pricing(model: str) -> Optional[Tuple[int, int]]:
+    for prefix, pricing in _MODEL_PRICING.items():
+        if model.startswith(prefix):
+            return pricing
+    return None
+
+
+def _resolve_api_key(explicit: Optional[str]) -> Optional[str]:
+    if explicit:
+        return explicit
+    return (
+        os.getenv("LLM_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+        or os.getenv("ZHIPUAI_API_KEY")
+        or os.getenv("GLM_API_KEY")
+    )
+
+
+def _resolve_base_url(provider: Optional[str], explicit: Optional[str]) -> Optional[str]:
+    if explicit:
+        return explicit
+    if not provider:
+        return None
+    provider = provider.lower()
+    if provider in {"glm", "zhipuai"}:
+        return get_settings().glm_base_url
+    return None
+
+
+def _coerce_usage(usage: Any) -> Tuple[int, int, int]:
+    if not usage:
+        return 0, 0, 0
+    prompt = 0
+    completion = 0
+    total = 0
+    for key in ("prompt_tokens", "promptTokens", "input_tokens"):
+        if isinstance(usage, dict):
+            prompt = int(usage.get(key, prompt)) or prompt
+        else:
+            prompt = int(getattr(usage, key, prompt) or prompt)
+        if prompt:
+            break
+    for key in ("completion_tokens", "output_tokens"):
+        if isinstance(usage, dict):
+            completion = int(usage.get(key, completion)) or completion
+        else:
+            completion = int(getattr(usage, key, completion) or completion)
+        if completion:
+            break
+    for key in ("total_tokens", "totalTokens"):
+        if isinstance(usage, dict):
+            total = int(usage.get(key, total)) or total
+        else:
+            total = int(getattr(usage, key, total) or total)
+        if total:
+            break
+    if not total:
+        total = prompt + completion
+    return prompt, completion, total
+
+
+async def call_llm(
+    *,
+    messages: Iterable[Dict[str, str]],
+    model: str,
+    provider: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    temperature: float = 0.7,
+    max_tokens: Optional[int] = None,
+    response_format: Optional[Dict[str, Any]] = None,
+    extra_params: Optional[Dict[str, Any]] = None,
+) -> Tuple[Any, CallStats]:
+    """Execute an OpenAI-compatible chat completion and return stats."""
+
+    resolved_key = _resolve_api_key(api_key) or get_settings().llm_api_key or ""
+    resolved_base = _resolve_base_url(provider, base_url)
+
+    client = AsyncOpenAI(api_key=resolved_key, base_url=resolved_base)
+
+    params: Dict[str, Any] = {
+        "model": model,
+        "messages": list(messages),
+        "temperature": temperature,
+    }
+    if max_tokens is not None:
+        params["max_tokens"] = max_tokens
+    if response_format is not None:
+        params["response_format"] = response_format
+    if extra_params:
+        params.update(extra_params)
+
+    try:
+        response = await client.chat.completions.create(**params)
+    except Exception:
+        return None, CallStats(model=model)
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens, completion_tokens, total_tokens = _coerce_usage(usage)
+    pricing = _resolve_pricing(model)
+    cost_cents = 0
+    if pricing:
+        in_cents, out_cents = pricing
+        cost = (prompt_tokens / 1_000_000) * in_cents + (completion_tokens / 1_000_000) * out_cents
+        cost_cents = int(round(cost))
+
+    stats = CallStats(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost_cents=cost_cents,
+    )
+    return response, stats

--- a/app/backend/app/services/relation_factory.py
+++ b/app/backend/app/services/relation_factory.py
@@ -1,25 +1,47 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import hashlib
 import json
-import os
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..agents.relation_factory_agent import run_relation_factory_once
+from ..ai_registry import get_relation_factory_prompt
+from ..config import get_settings
+from ..db import audit as audit_db
 from ..db import models
 from ..schemas.relations import CandidatePayload, CanvasSubmitRequest, EvidenceSnippet
+from .audit import audit_stage
+from .provider import CallStats, call_llm
 
-ARTIFACT_ROOT = Path("artifacts/audit").resolve()
+
+@dataclass
+class PipelineContext:
+    relation_id: str
+    subject: str
+    predicate: str
+    obj: str
+    request: CanvasSubmitRequest
+    subject_quote: str = ""
+    object_quote: str = ""
+    fts_hit: Optional[tuple[str, str]] = None
+    evidence_payload: list[dict[str, str]] = field(default_factory=list)
+    fused_claim: Optional[str] = None
+    fused_reason: Optional[str] = None
+    fused_evidence: list[EvidenceSnippet] = field(default_factory=list)
+    llm_response: Any = None
+    llm_stats: Optional[CallStats] = None
+    uniq_key: Optional[str] = None
 
 
 async def check_blacklist(session: AsyncSession, uniq_key: str) -> bool:
-    result = await session.execute(select(models.RelationReject).where(models.RelationReject.uniq_key == uniq_key))
+    result = await session.execute(
+        select(models.RelationReject).where(models.RelationReject.uniq_key == uniq_key)
+    )
     return result.scalar_one_or_none() is not None
 
 
@@ -28,7 +50,10 @@ def normalize_claim(subject: str, predicate: str, obj: str, claim: str) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def build_candidate_from_relation(relation: models.Relation, evidences: list[models.RelationEvidence]) -> CandidatePayload:
+def build_candidate_from_relation(
+    relation: models.Relation,
+    evidences: list[models.RelationEvidence],
+) -> CandidatePayload:
     evidence_payload = [
         EvidenceSnippet(
             note=ev.note_id,
@@ -61,12 +86,16 @@ def build_candidate_from_relation(relation: models.Relation, evidences: list[mod
     )
 
 
-async def _fts_best_match(session: AsyncSession, subject: str, query: str) -> Optional[tuple[str, str]]:
+async def _fts_best_match(
+    session: AsyncSession,
+    subject: str,
+    query: str,
+) -> Optional[tuple[str, str]]:
     """Return (note_id, snippet) for the best FTS match different from subject."""
-    # naive FTS: look up via notes_fts MATCH, prefer different note
     try:
         res = await session.execute(
-            "SELECT id, snippet(notes_fts, -1, '', '', ' … ', 64) as snip FROM notes_fts WHERE notes_fts MATCH :q LIMIT 5",
+            "SELECT id, snippet(notes_fts, -1, '', '', ' … ', 64) as snip "
+            "FROM notes_fts WHERE notes_fts MATCH :q LIMIT 5",
             {"q": query},
         )
         rows = res.fetchall()
@@ -78,138 +107,291 @@ async def _fts_best_match(session: AsyncSession, subject: str, query: str) -> Op
     return None
 
 
+def _response_to_payload(response: Any) -> Any:
+    if response is None:
+        return None
+    for attr in ("model_dump", "dict", "to_dict"):
+        method = getattr(response, attr, None)
+        if callable(method):
+            try:
+                return method()
+            except Exception:
+                continue
+    return response
+
+
+def _extract_message_content(response: Any) -> str:
+    if response is None:
+        return ""
+    payload = response
+    if isinstance(payload, dict):
+        choices = payload.get("choices") or []
+    else:
+        choices = getattr(payload, "choices", [])
+    if not choices:
+        return ""
+    choice = choices[0]
+    message = None
+    if isinstance(choice, dict):
+        message = choice.get("message") or choice.get("delta")
+    else:
+        message = getattr(choice, "message", None) or getattr(choice, "delta", None)
+    content = None
+    if isinstance(message, dict):
+        content = message.get("content") or message.get("text")
+    else:
+        content = getattr(message, "content", None)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text", ""))
+            else:
+                parts.append(str(item))
+        return "".join(parts)
+    if isinstance(content, str):
+        return content
+    if content is None and isinstance(message, dict):
+        return message.get("text", "") or ""
+    return str(content or "")
+
+
+def _fallback_fuse(context: PipelineContext) -> tuple[str, str, list[EvidenceSnippet]]:
+    claim = (
+        f"你输入提示 {context.subject} 与 {context.obj} 在主题上形成"
+        f"{context.predicate}连接。"
+    )
+    explain = "连接原因：它从另一个角度推进了你刚写的主题。"
+    evidence = [
+        EvidenceSnippet(**ev) for ev in context.evidence_payload[:2]
+    ]
+    return claim, explain, evidence
+
+
 async def run_relation_factory(
     session: AsyncSession,
     request: CanvasSubmitRequest,
 ) -> Optional[CandidatePayload]:
+    settings = get_settings()
     subject = request.note_id or "Z_subject_auto"
     predicate = request.predicate or "supports"
     obj = "Z_object_auto"
-
-    # real evidence: subject content + FTS top snippet from other note
-    subj_note = await session.get(models.Note, subject)
-    subj_quote = (subj_note.content[:140] if subj_note and subj_note.content else request.content[:140])
-
-    fts_hit = await _fts_best_match(session, subject, request.content[:128])
-    if fts_hit:
-        obj, snip = fts_hit
-        obj_note = await session.get(models.Note, obj)
-        obj_quote = (obj_note.content[:140] if obj_note and obj_note.content else (snip or request.content[:80]))
-    else:
-        obj_quote = request.content[:80]
-
-    def evidence_provider() -> dict:
-        return {
-            "evidence": [
-                {"note": subject, "span": "L1-L12", "quote": subj_quote},
-                {"note": obj, "span": "L20-L36", "quote": obj_quote},
-            ]
-        }
-
-    fused = await run_relation_factory_once(
-        subject=subject,
-        predicate=predicate,
-        content=request.content,
-        evidence_provider=evidence_provider,
-    )
-
-    if not fused or not fused.evidence:
-        claim = f"你的输入提示 {subject} 与 {obj} 在主题上形成{predicate}连接。"
-        explain = "连接原因：它从另一个角度推进了你刚写的主题。"
-        ev = evidence_provider()["evidence"]
-        fused_claim = claim
-        fused_reason = explain
-        fused_evidence = [EvidenceSnippet(**ev[0]), EvidenceSnippet(**ev[1])]
-    else:
-        fused_claim = fused.claim
-        fused_reason = fused.reason
-        fused_evidence = fused.evidence
-
-    uniq_key = normalize_claim(subject, predicate, obj, fused_claim)
-    if await check_blacklist(session, uniq_key):
-        return None
-
-    existing_rel_result = await session.execute(
-        select(models.Relation).where(models.Relation.uniq_key == uniq_key)
-    )
-    existing_relation = existing_rel_result.scalar_one_or_none()
-    if existing_relation is not None:
-        evidences_res = await session.execute(
-            select(models.RelationEvidence).where(
-                models.RelationEvidence.rel_id == existing_relation.id
-            )
-        )
-        evidences = evidences_res.scalars().all()
-        return build_candidate_from_relation(existing_relation, evidences)
-
     relation_id = f"Rel_{uuid4().hex[:12]}"
-    now = datetime.now(timezone.utc)
 
-    relation = models.Relation(
-        id=relation_id,
+    context = PipelineContext(
+        relation_id=relation_id,
         subject=subject,
         predicate=predicate,
-        object=obj,
-        claim=fused_claim,
-        reason=fused_reason,
-        confidence=0.72,
-        status="proposed",
-        created_at=now,
-        updated_at=now,
-        event_time=now,
-        valid_from=now,
-        uniq_key=uniq_key,
-        bm25=0.34,
-        cos=0.78,
-        npmi=0.41,
-        time_fresh=0.55,
-        path2=0.45,
-        novelty=0.66,
-        score=0.68,
+        obj=obj,
+        request=request,
     )
 
-    session.add(relation)
-
-    ev_models: list[models.RelationEvidence] = []
-    for ev in fused_evidence[:2]:
-        ev_models.append(
-            models.RelationEvidence(
-                rel_id=relation_id,
-                note_id=ev.note,
-                span=ev.span,
-                kind="note",
-                quote=ev.quote,
-                quote_sha=hashlib.sha256(ev.quote.encode("utf-8")).hexdigest() if ev.quote else None,
-            )
-        )
-
-    session.add_all(ev_models)
-
-    # Minimal audit artifact (fuse stage)
-    try:
-        run_id = f"run_{relation_id}"
-        ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)
-        (ARTIFACT_ROOT / f"{run_id}_fuse.json").write_text(
-            json.dumps(
-                {
-                    "subject": subject,
-                    "predicate": predicate,
-                    "object": obj,
-                    "input": request.content,
-                    "fused": {
-                        "claim": fused_claim,
-                        "reason": fused_reason,
-                        "evidence": [e.model_dump() for e in fused_evidence],
-                    },
-                    "created_at": now.isoformat(),
+    # Recall stage
+    async with audit_stage(session, relation_id, "recall") as (dump, run_id):
+        subj_note = await session.get(models.Note, subject)
+        subject_quote = request.content[:140]
+        if subj_note and getattr(subj_note, "content", None):
+            subject_quote = subj_note.content[:140]
+        context.subject_quote = subject_quote
+        dump(
+            "recall",
+            {
+                "request": request.model_dump(mode="json"),
+                "subject_note": {
+                    "id": subj_note.id if subj_note else None,
+                    "excerpt": subj_note.content[:280] if subj_note and subj_note.content else None,
                 },
-                ensure_ascii=False,
-            ),
-            encoding="utf-8",
+            },
         )
-    except Exception:
-        pass
 
-    await session.commit()
+    # Probe stage
+    async with audit_stage(session, relation_id, "probe") as (dump, run_id):
+        fts_hit = await _fts_best_match(session, subject, request.content[:128])
+        context.fts_hit = fts_hit
+        if fts_hit:
+            obj_candidate, snip = fts_hit
+            context.obj = obj_candidate
+            obj_note = await session.get(models.Note, obj_candidate)
+            if obj_note and getattr(obj_note, "content", None):
+                context.object_quote = obj_note.content[:140]
+            else:
+                context.object_quote = (snip or request.content[:80])
+            dump(
+                "probe",
+                {
+                    "fts_hit": {
+                        "note": obj_candidate,
+                        "snippet": snip,
+                    },
+                    "object_excerpt": context.object_quote,
+                },
+            )
+        else:
+            context.object_quote = request.content[:80]
+            dump("probe", {"fts_hit": None, "object_excerpt": context.object_quote})
 
-    return build_candidate_from_relation(relation, ev_models)
+    # Tri stage
+    async with audit_stage(session, relation_id, "tri") as (dump, run_id):
+        context.evidence_payload = [
+            {"note": context.subject, "span": "L1-L12", "quote": context.subject_quote},
+            {"note": context.obj, "span": "L20-L36", "quote": context.object_quote},
+        ]
+        dump("tri", {"evidence": context.evidence_payload})
+
+    # Fuse stage
+    provider = settings.llm_provider or "openai"
+    model_name = settings.relation_factory_model
+    async with audit_stage(
+        session,
+        relation_id,
+        "fuse",
+        model_ctx={"provider": provider, "model": model_name},
+    ) as (dump, run_id):
+        evidence_json = json.dumps(context.evidence_payload, ensure_ascii=False, indent=2)
+        user_prompt = (
+            f"目标关系: {predicate}\n"
+            f"主题(subject): {context.subject}\n"
+            f"客体(object): {context.obj}\n"
+            f"新输入片段: {request.content[:400]}\n\n"
+            "请依据 evidence 中的引用生成 JSON 对象，包含 claim、reason、evidence 三个字段。"
+        )
+        messages = [
+            {"role": "system", "content": get_relation_factory_prompt()},
+            {"role": "user", "content": f"{user_prompt}\nEvidence:\n{evidence_json}"},
+        ]
+        response, stats = await call_llm(
+            messages=messages,
+            model=model_name,
+            provider=provider,
+            temperature=0.2,
+            max_tokens=600,
+            response_format={"type": "json_object"},
+        )
+        context.llm_stats = stats
+        context.llm_response = _response_to_payload(response)
+        await audit_db.audit_runs_insert_tokens(session=session, run_id=run_id, stats=stats)
+        dump("fuse_messages", messages)
+        dump("fuse_response", context.llm_response)
+        dump("fuse_stats", asdict(stats))
+
+        parsed_output: Optional[dict[str, Any]] = None
+        if isinstance(context.llm_response, dict):
+            message_content = _extract_message_content(context.llm_response)
+        else:
+            message_content = _extract_message_content(response)
+        if message_content:
+            try:
+                parsed_output = json.loads(message_content)
+            except json.JSONDecodeError:
+                parsed_output = None
+        if parsed_output and isinstance(parsed_output, dict):
+            context.fused_claim = parsed_output.get("claim")
+            context.fused_reason = parsed_output.get("reason")
+            evidence_items = parsed_output.get("evidence", [])
+            if isinstance(evidence_items, list):
+                context.fused_evidence = []
+                for item in evidence_items:
+                    if isinstance(item, dict) and {"note", "span", "quote"} <= set(item.keys()):
+                        context.fused_evidence.append(EvidenceSnippet(**item))
+
+    # Judge stage
+    async with audit_stage(session, relation_id, "judge") as (dump, run_id):
+        if not context.evidence_payload:
+            context.evidence_payload = [
+                {"note": context.subject, "span": "L1-L12", "quote": context.subject_quote},
+                {"note": context.obj, "span": "L20-L36", "quote": context.object_quote},
+            ]
+        if not context.fused_claim or not context.fused_reason or not context.fused_evidence:
+            context.fused_claim, context.fused_reason, context.fused_evidence = _fallback_fuse(context)
+        context.uniq_key = normalize_claim(
+            context.subject, context.predicate, context.obj, context.fused_claim
+        )
+        dump(
+            "judge_candidate",
+            {
+                "claim": context.fused_claim,
+                "reason": context.fused_reason,
+                "evidence": [ev.model_dump(mode="json") for ev in context.fused_evidence],
+                "uniq_key": context.uniq_key,
+            },
+        )
+
+        if await check_blacklist(session, context.uniq_key):
+            dump("judge_decision", {"status": "rejected", "reason": "blacklist"})
+            return None
+
+        existing_rel_result = await session.execute(
+            select(models.Relation).where(models.Relation.uniq_key == context.uniq_key)
+        )
+        existing_relation = existing_rel_result.scalar_one_or_none()
+        if existing_relation is not None:
+            evidences_res = await session.execute(
+                select(models.RelationEvidence).where(
+                    models.RelationEvidence.rel_id == existing_relation.id
+                )
+            )
+            evidences = evidences_res.scalars().all()
+            dump(
+                "judge_decision",
+                {"status": "existing", "relation_id": existing_relation.id},
+            )
+            return build_candidate_from_relation(existing_relation, evidences)
+
+        now = datetime.now(timezone.utc)
+        relation = models.Relation(
+            id=relation_id,
+            subject=context.subject,
+            predicate=context.predicate,
+            object=context.obj,
+            claim=context.fused_claim,
+            reason=context.fused_reason,
+            confidence=0.72,
+            status="proposed",
+            created_at=now,
+            updated_at=now,
+            event_time=now,
+            valid_from=now,
+            uniq_key=context.uniq_key,
+            bm25=0.34,
+            cos=0.78,
+            npmi=0.41,
+            time_fresh=0.55,
+            path2=0.45,
+            novelty=0.66,
+            score=0.68,
+        )
+        session.add(relation)
+
+        ev_models: list[models.RelationEvidence] = []
+        for ev in context.fused_evidence[:2]:
+            ev_models.append(
+                models.RelationEvidence(
+                    rel_id=relation_id,
+                    note_id=ev.note,
+                    span=ev.span,
+                    kind="note",
+                    quote=ev.quote,
+                    quote_sha=hashlib.sha256(ev.quote.encode("utf-8")).hexdigest() if ev.quote else None,
+                )
+            )
+        session.add_all(ev_models)
+        await session.commit()
+
+        dump(
+            "judge_decision",
+            {
+                "status": "created",
+                "relation_id": relation_id,
+                "evidence": [
+                    {
+                        "note": ev.note_id,
+                        "span": ev.span,
+                        "quote": ev.quote,
+                        "quote_sha": ev.quote_sha,
+                    }
+                    for ev in ev_models
+                ],
+            },
+        )
+
+        return build_candidate_from_relation(relation, ev_models)


### PR DESCRIPTION
## Summary
- add a provider service with reusable CallStats helper and OpenAI-compatible wrapper
- persist audit metadata via async audit_stage updates and new DB helpers
- refactor the relation factory pipeline to audit each stage and record LLM usage statistics

## Testing
- pytest tests/discovery_core_test.py

------
https://chatgpt.com/codex/tasks/task_b_68ca36227fc48328b9435e2411ea8f52