### PR TITLE
Fix relation factory query and provider handling

### DIFF
--- a/app/backend/app/services/provider.py
+++ b/app/backend/app/services/provider.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import os
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 from openai import AsyncOpenAI
@@ -29,6 +32,8 @@ _MODEL_PRICING: Dict[str, Tuple[int, int]] = {
     "glm-4-air": (20, 80),
 }
 
+_AGENTSCOPE_MODEL_CACHE: Optional[Dict[str, Any]] = None
+
 
 def _resolve_pricing(model: str) -> Optional[Tuple[int, int]]:
     for prefix, pricing in _MODEL_PRICING.items():
@@ -45,6 +50,11 @@ def _resolve_api_key(explicit: Optional[str]) -> Optional[str]:
         or os.getenv("OPENAI_API_KEY")
         or os.getenv("ZHIPUAI_API_KEY")
         or os.getenv("GLM_API_KEY")
+        or os.getenv("DASHSCOPE_API_KEY")
+        or os.getenv("ANTHROPIC_API_KEY")
+        or os.getenv("GEMINI_API_KEY")
+        or os.getenv("GOOGLE_API_KEY")
+        or os.getenv("OLLAMA_API_KEY")
     )
 
 
@@ -56,7 +66,235 @@ def _resolve_base_url(provider: Optional[str], explicit: Optional[str]) -> Optio
     provider = provider.lower()
     if provider in {"glm", "zhipuai"}:
         return get_settings().glm_base_url
+    if provider == "ollama":
+        return os.getenv("OLLAMA_BASE_URL")
     return None
+
+
+def _load_agentscope_models() -> Optional[Dict[str, Any]]:
+    global _AGENTSCOPE_MODEL_CACHE
+    if _AGENTSCOPE_MODEL_CACHE is not None:
+        return _AGENTSCOPE_MODEL_CACHE
+
+    try:
+        from agentscope.model import (
+            AnthropicChatModel,
+            DashScopeChatModel,
+            GeminiChatModel,
+            OllamaChatModel,
+        )
+    except ImportError:
+        root = Path(__file__).resolve().parents[4]
+        src_path = root / "src"
+        if src_path.exists() and str(src_path) not in sys.path:
+            sys.path.append(str(src_path))
+        try:
+            from agentscope.model import (
+                AnthropicChatModel,
+                DashScopeChatModel,
+                GeminiChatModel,
+                OllamaChatModel,
+            )
+        except ImportError:
+            _AGENTSCOPE_MODEL_CACHE = None
+            return None
+
+    _AGENTSCOPE_MODEL_CACHE = {
+        "dashscope": DashScopeChatModel,
+        "anthropic": AnthropicChatModel,
+        "gemini": GeminiChatModel,
+        "ollama": OllamaChatModel,
+    }
+    return _AGENTSCOPE_MODEL_CACHE
+
+
+def _chat_response_to_openai_payload(response: Any) -> Any:
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        return response
+
+    content_blocks = getattr(response, "content", None)
+    if not isinstance(content_blocks, list):
+        return response
+
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_parts.append(block.get("text", ""))
+        elif block_type == "tool_use":
+            try:
+                arguments = json.dumps(block.get("input", {}))
+            except (TypeError, ValueError):
+                arguments = ""
+            tool_calls.append(
+                {
+                    "id": block.get("id") or "",
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name") or "",
+                        "arguments": arguments,
+                    },
+                }
+            )
+
+    message: dict[str, Any] = {
+        "role": "assistant",
+        "content": "".join(text_parts),
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    payload: dict[str, Any] = {"choices": [{"message": message}]}
+
+    metadata = getattr(response, "metadata", None)
+    if metadata is not None:
+        payload["choices"][0]["message"]["metadata"] = metadata
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens, completion_tokens, total_tokens = _coerce_usage(usage)
+    if prompt_tokens or completion_tokens or total_tokens:
+        payload["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        }
+
+    return payload
+
+
+async def _call_openai_like(
+    *,
+    messages: Iterable[Dict[str, str]],
+    model: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    temperature: float,
+    max_tokens: Optional[int],
+    response_format: Optional[Dict[str, Any]],
+    extra_params: Optional[Dict[str, Any]],
+) -> Tuple[Any, CallStats]:
+    client_kwargs: Dict[str, Any] = {"api_key": api_key or None}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+    client = AsyncOpenAI(**client_kwargs)
+
+    params: Dict[str, Any] = {
+        "model": model,
+        "messages": list(messages),
+        "temperature": temperature,
+    }
+    if max_tokens is not None:
+        params["max_tokens"] = max_tokens
+    if response_format is not None:
+        params["response_format"] = response_format
+    if extra_params:
+        params.update(extra_params)
+
+    try:
+        response = await client.chat.completions.create(**params)
+    except Exception:
+        return None, CallStats(model=model)
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens, completion_tokens, total_tokens = _coerce_usage(usage)
+    pricing = _resolve_pricing(model)
+    cost_cents = 0
+    if pricing:
+        in_cents, out_cents = pricing
+        cost = (prompt_tokens / 1_000_000) * in_cents + (completion_tokens / 1_000_000) * out_cents
+        cost_cents = int(round(cost))
+
+    stats = CallStats(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost_cents=cost_cents,
+    )
+    return response, stats
+
+
+async def _call_agentscope_model(
+    provider: str,
+    *,
+    messages: Iterable[Dict[str, str]],
+    model: str,
+    api_key: Optional[str],
+    base_url: Optional[str],
+    temperature: float,
+    max_tokens: Optional[int],
+    response_format: Optional[Dict[str, Any]],
+    extra_params: Optional[Dict[str, Any]],
+) -> Tuple[Any, CallStats]:
+    adapters = _load_agentscope_models()
+    if not adapters or provider not in adapters:
+        return None, CallStats(model=model)
+
+    ModelCls = adapters[provider]
+    init_kwargs: Dict[str, Any] = {"model_name": model, "stream": False}
+
+    if provider != "ollama":
+        init_kwargs["api_key"] = api_key
+    else:
+        if base_url:
+            init_kwargs["host"] = base_url
+
+    if provider == "dashscope" and base_url:
+        init_kwargs["base_http_api_url"] = base_url
+
+    try:
+        model_client = ModelCls(**init_kwargs)
+    except Exception:
+        return None, CallStats(model=model)
+
+    call_kwargs: Dict[str, Any] = {}
+    if temperature is not None:
+        call_kwargs["temperature"] = temperature
+    if max_tokens is not None:
+        call_kwargs["max_tokens"] = max_tokens
+    if extra_params:
+        call_kwargs.update(extra_params)
+    if response_format is not None:
+        call_kwargs.setdefault("response_format", response_format)
+
+    try:
+        response = await model_client(list(messages), **call_kwargs)
+    except Exception:
+        return None, CallStats(model=model)
+
+    payload = _chat_response_to_openai_payload(response)
+    usage = getattr(response, "usage", None)
+    prompt_tokens, completion_tokens, total_tokens = _coerce_usage(usage)
+
+    stats = CallStats(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost_cents=0,
+    )
+    return payload, stats
+
+
+async def _call_dashscope(**kwargs: Any) -> Tuple[Any, CallStats]:
+    return await _call_agentscope_model("dashscope", **kwargs)
+
+
+async def _call_anthropic(**kwargs: Any) -> Tuple[Any, CallStats]:
+    return await _call_agentscope_model("anthropic", **kwargs)
+
+
+async def _call_gemini(**kwargs: Any) -> Tuple[Any, CallStats]:
+    return await _call_agentscope_model("gemini", **kwargs)
+
+
+async def _call_ollama(**kwargs: Any) -> Tuple[Any, CallStats]:
+    return await _call_agentscope_model("ollama", **kwargs)
 
 
 def _coerce_usage(usage: Any) -> Tuple[int, int, int]:
@@ -105,42 +343,30 @@ async def call_llm(
 ) -> Tuple[Any, CallStats]:
     """Execute an OpenAI-compatible chat completion and return stats."""
 
-    resolved_key = _resolve_api_key(api_key) or get_settings().llm_api_key or ""
-    resolved_base = _resolve_base_url(provider, base_url)
-
-    client = AsyncOpenAI(api_key=resolved_key, base_url=resolved_base)
+    provider_normalized = (provider or "openai").lower()
+    resolved_key = _resolve_api_key(api_key) or get_settings().llm_api_key or None
+    resolved_base = _resolve_base_url(provider_normalized, base_url)
 
     params: Dict[str, Any] = {
-        "model": model,
         "messages": list(messages),
+        "model": model,
+        "api_key": resolved_key,
+        "base_url": resolved_base,
         "temperature": temperature,
+        "max_tokens": max_tokens,
+        "response_format": response_format,
+        "extra_params": extra_params,
     }
-    if max_tokens is not None:
-        params["max_tokens"] = max_tokens
-    if response_format is not None:
-        params["response_format"] = response_format
-    if extra_params:
-        params.update(extra_params)
 
-    try:
-        response = await client.chat.completions.create(**params)
-    except Exception:
-        return None, CallStats(model=model)
+    if provider_normalized in {"openai", "glm", "zhipuai", None}:
+        return await _call_openai_like(**params)
+    if provider_normalized == "dashscope":
+        return await _call_dashscope(**params)
+    if provider_normalized == "anthropic":
+        return await _call_anthropic(**params)
+    if provider_normalized == "gemini":
+        return await _call_gemini(**params)
+    if provider_normalized == "ollama":
+        return await _call_ollama(**params)
 
-    usage = getattr(response, "usage", None)
-    prompt_tokens, completion_tokens, total_tokens = _coerce_usage(usage)
-    pricing = _resolve_pricing(model)
-    cost_cents = 0
-    if pricing:
-        in_cents, out_cents = pricing
-        cost = (prompt_tokens / 1_000_000) * in_cents + (completion_tokens / 1_000_000) * out_cents
-        cost_cents = int(round(cost))
-
-    stats = CallStats(
-        model=model,
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        total_tokens=total_tokens,
-        cost_cents=cost_cents,
-    )
-    return response, stats
+    return await _call_openai_like(**params)

--- a/app/backend/app/services/relation_factory.py
+++ b/app/backend/app/services/relation_factory.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import uuid4
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..ai_registry import get_relation_factory_prompt
@@ -93,11 +93,11 @@ async def _fts_best_match(
 ) -> Optional[tuple[str, str]]:
     """Return (note_id, snippet) for the best FTS match different from subject."""
     try:
-        res = await session.execute(
-            "SELECT id, snippet(notes_fts, -1, '', '', ' … ', 64) as snip "
-            "FROM notes_fts WHERE notes_fts MATCH :q LIMIT 5",
-            {"q": query},
+        stmt = text(
+            "SELECT id, snippet(notes_fts, -1, '', '', ' … ', 64) AS snip "
+            "FROM notes_fts WHERE notes_fts MATCH :q LIMIT 5"
         )
+        res = await session.execute(stmt, {"q": query})
         rows = res.fetchall()
         for rid, snip in rows:
             if rid != subject:

--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[tool.poetry]
+[tool.poetry]
 name = "relation-zettel-backend"
 version = "0.1.0"
 description = "FastAPI service for the Relation-Zettel platform"

--- a/app/backend/tests/test_relation_factory_service.py
+++ b/app/backend/tests/test_relation_factory_service.py
@@ -1,0 +1,136 @@
+import json
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ["DATABASE_URL"] = "sqlite+aiosqlite:///./test_relation_zettel.db"
+
+from app.config import get_settings
+from app.db import models
+from app.db.session import SessionLocal, engine
+from app.schemas.relations import CanvasSubmitRequest
+from app.services.fts import ensure_fts, rebuild_fts
+from app.services import provider as provider_module
+from app.services.provider import CallStats
+from app.services.relation_factory import _fts_best_match, run_relation_factory
+
+
+@pytest.fixture(autouse=True)
+async def prepare_database():
+    async with engine.begin() as conn:
+        await conn.run_sync(models.Base.metadata.drop_all)
+        await conn.run_sync(models.Base.metadata.create_all)
+    await ensure_fts(engine)
+    yield
+
+
+@pytest.fixture
+async def session():
+    async with SessionLocal() as db:
+        yield db
+
+
+async def _seed_notes(db, subject_id: str = "note-subject", object_id: str = "note-object"):
+    subject_note = models.Note(
+        id=subject_id,
+        title="Subject",
+        content="Alpha beta gamma",
+        tags="",
+    )
+    object_note = models.Note(
+        id=object_id,
+        title="Object",
+        content="Magic keyword content for matching",
+        tags="",
+    )
+    db.add_all([subject_note, object_note])
+    await db.commit()
+    await rebuild_fts(engine)
+    return subject_note.id, object_note.id
+
+
+@pytest.mark.asyncio
+async def test_fts_best_match_returns_hit(session):
+    subject_id, other_id = await _seed_notes(session)
+
+    hit = await _fts_best_match(session, subject_id, "magic keyword")
+
+    assert hit is not None
+    note_id, snippet = hit
+    assert note_id == other_id
+    assert isinstance(snippet, str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_name, helper_name",
+    [
+        ("dashscope", "_call_dashscope"),
+        ("anthropic", "_call_anthropic"),
+        ("gemini", "_call_gemini"),
+        ("ollama", "_call_ollama"),
+    ],
+)
+async def test_run_relation_factory_uses_non_openai_providers(
+    session, monkeypatch, provider_name, helper_name
+):
+    subject_id, other_id = await _seed_notes(session)
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": json.dumps(
+                        {
+                            "claim": f"{provider_name} claim",
+                            "reason": "Stubbed reasoning",
+                            "evidence": [
+                                {
+                                    "note": subject_id,
+                                    "span": "L1-L2",
+                                    "quote": "Alpha beta gamma",
+                                },
+                                {
+                                    "note": other_id,
+                                    "span": "L3-L4",
+                                    "quote": "Magic keyword content for matching",
+                                },
+                            ],
+                        }
+                    )
+                }
+            }
+        ],
+        "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20},
+    }
+    stats = CallStats(
+        model="stub-model",
+        prompt_tokens=12,
+        completion_tokens=8,
+        total_tokens=20,
+        cost_cents=0,
+    )
+
+    helper_mock = AsyncMock(return_value=(payload, stats))
+    monkeypatch.setattr(provider_module, helper_name, helper_mock)
+
+    monkeypatch.setenv("LLM_PROVIDER", provider_name)
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    get_settings.cache_clear()
+
+    request = CanvasSubmitRequest(
+        content="Magic keyword ties the notes together",
+        note_id=subject_id,
+        predicate="supports",
+    )
+
+    try:
+        candidate = await run_relation_factory(session, request)
+    finally:
+        get_settings.cache_clear()
+
+    assert candidate is not None
+    assert candidate.claim == f"{provider_name} claim"
+    assert candidate.evidence[1].note == other_id
+    assert helper_mock.await_count == 1


### PR DESCRIPTION
## Summary
- execute the note FTS lookup with `sqlalchemy.text` to keep recall working on SQLAlchemy 2.x
- branch the relation factory provider client so dashscope/anthropic/gemini/ollama requests go through the appropriate Agentscope adapters and return OpenAI-style payloads
- add regression coverage that exercises the fixed FTS helper and stubs each non-OpenAI provider path
- strip the stray BOM from `app/backend/pyproject.toml` so pytest can parse the config file

## Testing
- `PYTHONPATH=app/backend pytest app/backend/tests/test_relation_factory_service.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68cd4b2e0cdc83288600016e435b5db4